### PR TITLE
updating php version in installer script to php-7.1.7

### DIFF
--- a/bin/php-installer.ps1
+++ b/bin/php-installer.ps1
@@ -1,4 +1,4 @@
-$phpUrl = "http://windows.php.net/downloads/releases/php-7.1.6-nts-Win32-VC14-x86.zip"
+$phpUrl = "http://windows.php.net/downloads/releases/php-7.1.7-nts-Win32-VC14-x86.zip"
 $phpIniUrl = "https://raw.githubusercontent.com/cretueusebiu/valet-windows/master/cli/stubs/php.ini"
 $caCertUrl = "https://curl.haxx.se/ca/cacert.pem"
 $zipfile = "$PSScriptRoot\php.zip"


### PR DESCRIPTION
When trying to install I was getting a 404 error trying to install php from 
http://windows.php.net/downloads/releases/php-7.1.6-nts-Win32-VC14-x86.zip

Upon inspection I found that the version had been bumped to 7.1.7, after forking and bumping the PHP version everything installed nicely for me.