### PR TITLE
bumping php to 7.1.8 in installer script

### DIFF
--- a/bin/php-installer.ps1
+++ b/bin/php-installer.ps1
@@ -1,4 +1,4 @@
-$phpUrl = "http://windows.php.net/downloads/releases/php-7.1.7-nts-Win32-VC14-x86.zip"
+$phpUrl = "http://windows.php.net/downloads/releases/php-7.1.8-nts-Win32-VC14-x86.zip"
 $phpIniUrl = "https://raw.githubusercontent.com/cretueusebiu/valet-windows/master/cli/stubs/php.ini"
 $caCertUrl = "https://curl.haxx.se/ca/cacert.pem"
 $zipfile = "$PSScriptRoot\php.zip"


### PR DESCRIPTION
Updating the php version from 7.1.7 to 7.1.8, is there any way to determine a link for this that is always the latest version of php so that it wouldn't be necessary to manually bump the version every time php releases a patch?