### PR TITLE
pulling latest patch version of php from releases page

### DIFF
--- a/bin/php-installer.ps1
+++ b/bin/php-installer.ps1
@@ -1,4 +1,14 @@
-$phpUrl = "http://windows.php.net/downloads/releases/php-7.1.8-nts-Win32-VC14-x86.zip"
+$phpBase = "http://windows.php.net"
+$phpPage = "http://windows.php.net/downloads/releases/"
+$phpResponse = Invoke-WebRequest $phpPage
+$phpUrl = ""
+ForEach ($Link in $phpResponse.Links)
+{
+  If( $Link.href -match "/downloads/releases/php-7\.1\.\d+?-nts-Win32-VC14-x86\.zip" ){
+    $phpUrl = (-join($phpBase, $Matches[0]))
+  }
+}
+
 $phpIniUrl = "https://raw.githubusercontent.com/cretueusebiu/valet-windows/master/cli/stubs/php.ini"
 $caCertUrl = "https://curl.haxx.se/ca/cacert.pem"
 $zipfile = "$PSScriptRoot\php.zip"


### PR DESCRIPTION
I'm new to doing much of anything with PowerShell so this may be sub-optimal but it seems like it works ok on my system for matching the most current patch version of php 7.1 and then setting it as the download link.