### PR TITLE
working offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For more please refer to the official documentation on the [Laravel website](htt
 - HTTP/2 does not work with secured sites.
 - When sharing sites the url will not be copied to the clipboard.
 - You must run the `valet` commands from the drive where Valet is installed, except for park and link. See [#12](https://github.com/cretueusebiu/valet-windows/issues/12#issuecomment-283111834).
-- If your machine is not connected to the internet you'll have to manually add the domains in your `hosts` file.
+- If your machine is not connected to the internet you'll have to manually add the domains in your `hosts` file OR you can install the "Microsoft Loopback Adapter" as this simulates an active local network interface that valet can bind too.
 
 ## Changelog
 


### PR DESCRIPTION
I was finding it a hassle to manually update and manage the hosts file for when I was working offline as I've been working offline more and more. The basic issue is valet needs to bind the acrylic service to an active interface. Windows comes already with an old network adapter called the Microsoft Loopback Adapter that you just have to turn on. Once it is added it shows up as a network connection and it seamlessly allows valet to work as expected whether you are online or offline.  To make it perform faster I set it up to use a fixed IPv4 address and I disabled IPv6. As a side note, I know some old exploits that used to take advantage of the loopback adapter that were long ago fixed but as it isn't installed by default for years now I don't know if new exploits are out there so I simply disable that network connection when I'm online and I re-enable it when I'm offline just to be safe.