### PR TITLE
Fix invalid certificate error in non-UTC timezones

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -354,6 +354,7 @@ class Site
 
         $x509 = new X509();
         $x509->makeCA();
+        $x509->setStartDate('-1 day');
 
         $result = $x509->sign($issuer, $subject, 'sha256WithRSAEncryption');
         $certificate = $x509->saveX509($result);

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -4,14 +4,14 @@
  * Load correct autoloader depending on install location.
  */
 if (file_exists(__DIR__.'/../vendor/autoload.php')) {
-    require __DIR__.'/../vendor/autoload.php';
+    require_once __DIR__.'/../vendor/autoload.php';
 } else {
-    require __DIR__.'/../../../autoload.php';
+    require_once __DIR__.'/../../../autoload.php';
 }
 
-require __DIR__.'/includes/compatibility.php';
-require __DIR__.'/includes/facades.php';
-require __DIR__.'/includes/helpers.php';
+require_once __DIR__.'/includes/compatibility.php';
+require_once __DIR__.'/includes/facades.php';
+require_once __DIR__.'/includes/helpers.php';
 
 use Silly\Application;
 use function Valet\info;


### PR DESCRIPTION
- Set certificate start date to '-1 day'
- Changed require to require_once in main script