### PR TITLE
Fix ssl redirect issue after running valet unsecure

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,7 +1,7 @@
 server {
     listen 80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
-    return 301 https://$host$request_uri;
+    return 302 https://$host$request_uri;
 }
 
 server {


### PR DESCRIPTION
Updates the valet secure configuration stub to use a 302 redirect instead of 301.  The reason for this is so that when you run valet unsecure you don't have to hard refresh and clear cache on your browser since 301 is a Permanent Redirect vs 302 being a Temporary Redirect.  This will be switch from secure to unsecure easier on the developer using valet.  Let me know if you have any questions or concerns.  Thanks, Kevin