### PR TITLE
Fix certificate keyUsage issue with newer browser versions

### DIFF
--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -326,6 +326,12 @@ class Site
             ['dNSName' => "*.$url"],
         ]);
 
+        $x509->setExtension('id-ce-keyUsage', [
+            'digitalSignature',
+            'nonRepudiation',
+            'keyEncipherment',
+        ]);
+
         $csr = $x509->saveCSR($x509->signCSR());
 
         $this->files->putAsUser($csrPath, $csr);


### PR DESCRIPTION
Updates the certificate createSigningRequest method to include extra keyUsage values.  The values added align with what core valet is adding to certificates.  It also prevents the following certificate issue in the browser when trying to use Laravel Sockets: 
ERR_SSL_KEY_USAGE_INCOMPATIBLE

I assume this is related to security upgrades to modern browsers.

Let me know if you have any questions or concerns.  Thanks, Kevin