### PR TITLE
Fix 404 Not Found issue #159

### DIFF
--- a/server.php
+++ b/server.php
@@ -139,11 +139,11 @@ foreach ($valetConfig['paths'] as $path) {
             }
 
             // match dir for lowercase, because Nginx only tells us lowercase names
-            if (strtolower($file) === $siteName) {
+            if ($file === $siteName) {
                 $valetSitePath = $path.'/'.$file;
                 break;
             }
-            if (strtolower($file) === $domain) {
+            if ($file === $domain) {
                 $valetSitePath = $path.'/'.$file;
             }
         }


### PR DESCRIPTION
This fixes issue #159 - $siteName and $domain are case sensitive, forcing $file to be lowercase means these variable do not match.

Is there a reason strtolower() was used here?