### PR TITLE
feat: add support for multiple PHP services

### DIFF
--- a/cli/Valet/Configuration.php
+++ b/cli/Valet/Configuration.php
@@ -200,7 +200,7 @@ class Configuration
     }
 
     /**
-     * Get the given php path configuration.
+     * Get the php configuration by path
      *
      * @param  string  $phpPath
      * @return mixed
@@ -213,6 +213,23 @@ class Configuration
 
         return collect($config['php'])->filter(function($item) use($phpPath) {
             return $phpPath === $item['path'];
+        })->first();
+    }
+
+    /**
+     * Get the php configuration by version
+     *
+     * @param  string  $phpVersion
+     * @return mixed
+     */
+    public function getPhpByVersion($phpVersion)
+    {
+        $phpVersion = str_replace(array('/', '\\'), DIRECTORY_SEPARATOR, $phpVersion);
+
+        $config = $this->read();
+
+        return collect($config['php'])->filter(function($item) use($phpVersion) {
+            return $phpVersion === $item['version'];
         })->first();
     }
 

--- a/cli/Valet/Nginx.php
+++ b/cli/Valet/Nginx.php
@@ -71,11 +71,14 @@ class Nginx
      */
     public function installConfiguration()
     {
+        $defaultPhpVersion = $this->configuration->get('default_php');
+        $defaultPhp = $this->configuration->getPhpByVersion($defaultPhpVersion);
+
         $this->files->putAsUser(
             $this->path('conf/nginx.conf'),
             str_replace(
                 ['VALET_USER', 'VALET_HOME_PATH', '__VALET_PHP_PORT__', '__VALET_PHP_XDEBUG_PORT__'],
-                [user(), VALET_HOME_PATH, $this->configuration->get('php_port', PhpCgi::PORT), $this->configuration->get('php_xdebug_port', PhpCgiXdebug::PORT)],
+                [user(), VALET_HOME_PATH, $defaultPhp['port'], $defaultPhp['xdebug_port']],
                 $this->files->get(__DIR__.'/../stubs/nginx.conf')
             )
         );

--- a/cli/Valet/Site.php
+++ b/cli/Valet/Site.php
@@ -398,6 +398,18 @@ class Site
      *
      * @return array
      */
+    public function publishParkedNginxConf($parkedPath)
+    {
+        $parked = $this->parked();
+
+        // TODO
+    }
+
+    /**
+     * Get all of the URLs that are currently secured.
+     *
+     * @return array
+     */
     public function secured()
     {
         return collect($this->files->scandir($this->certificatesPath()))
@@ -556,6 +568,26 @@ class Site
         $this->cli->runOrExit(sprintf('cmd "/C certutil -addstore "Root" "%s""', $crtPath), function ($code, $output) {
             error("Failed to trust certificate: $output");
         });
+    }
+
+    /**
+     * Build the unsecured Nginx server for the given URL.
+     *
+     * @param  string  $url
+     * @param  string  $siteConf  (optional) Nginx site config file content
+     * @return string
+     */
+    public function buildUnsecureNginxServer($url, $siteConf = null)
+    {
+        if ($siteConf === null) {
+            $siteConf = $this->files->get(__DIR__.'/../stubs/unsecure.valet.conf');
+        }
+
+        return str_replace(
+            ['VALET_HOME_PATH', 'VALET_SERVER_PATH', 'VALET_STATIC_PREFIX', 'VALET_SITE', 'HOME_PATH'],
+            [$this->valetHomePath(), VALET_SERVER_PATH, VALET_STATIC_PREFIX, $url, $_SERVER['HOME']],
+            $siteConf
+        );
     }
 
     /**

--- a/cli/stubs/phpcgiservice.xml
+++ b/cli/stubs/phpcgiservice.xml
@@ -1,6 +1,6 @@
 <service>
-  <id>valet_phpcgi</id>
-  <name>valet_phpcgi</name>
+  <id>PHPCGINAME</id>
+  <name>PHPCGINAME</name>
   <description>Valet PHP-CGI</description>
   <env name="PHP_FCGI_CHILDREN" value="4"/>
   <executable>PHP_PATH\php-cgi.exe</executable>

--- a/cli/stubs/phpcgixdebugservice.xml
+++ b/cli/stubs/phpcgixdebugservice.xml
@@ -1,6 +1,6 @@
 <service>
-  <id>valet_phpcgi_xdebug</id>
-  <name>valet_phpcgi_xdebug</name>
+  <id>PHPCGINAME</id>
+  <name>PHPCGINAME</name>
   <description>Valet PHP-CGI Xdebug</description>
   <env name="PHP_FCGI_CHILDREN" value="1"/>
   <executable>PHP_PATH\php-cgi.exe</executable>

--- a/cli/stubs/unsecure.valet.conf
+++ b/cli/stubs/unsecure.valet.conf
@@ -1,0 +1,40 @@
+server {
+    listen 80;
+    server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
+    root /;
+    charset utf-8;
+    client_max_body_size 512M;
+    http2_push_preload on;
+
+    location ~* /VALET_STATIC_PREFIX/([A-Z]+:)(.*) {
+        internal;
+        alias $1;
+        try_files $2 $2/;
+    }
+
+    location / {
+        rewrite ^ "VALET_SERVER_PATH" last;
+    }
+
+    # location = /favicon.ico { access_log off; log_not_found off; }
+    # location = /robots.txt  { access_log off; log_not_found off; }
+
+    access_log off;
+    error_log "VALET_HOME_PATH/Log/nginx-error.log";
+
+    error_page 404 "VALET_SERVER_PATH";
+
+    location ~ [^/]\.php(/|$) {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass 127.0.0.1:$valet_php_port;
+        fastcgi_index "VALET_SERVER_PATH";
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME "VALET_SERVER_PATH";
+        fastcgi_param HOME 'HOME_PATH';
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+}

--- a/cli/valet.php
+++ b/cli/valet.php
@@ -43,6 +43,78 @@ if (is_dir(VALET_HOME_PATH)) {
 }
 
 /**
+ * Add PHP
+ */
+$app->command('php:add [path]', function ($path) {
+    info("Adding {$path}...");
+
+    if($php = Configuration::addPhp($path)) {
+//        \PhpCgi::uninstall($php['version']);
+
+        \PhpCgi::install($php['version']);
+
+        info("PHP {$php['version']} from {$path} has been added. You can make it default by running `valet use` command");
+    }
+})->descriptions('Add PHP by specifying a path');
+
+/**
+ * Remove PHP
+ */
+$app->command('php:remove [path]', function ($path) {
+    info("Removing {$path}...");
+
+    if($php = Configuration::getPhp($path)) {
+        \PhpCgi::uninstall($php['version']);
+
+        \PhpCgiXdebug::uninstall($php['version']);
+    }
+
+    if(Configuration::removePhp($path)) {
+        info("PHP {$php['version']} from {$path} has been removed.");
+    }
+})->descriptions('Remove PHP by specifying a path');
+
+/**
+ */
+$app->command('php:install', function () {
+    info('Reinstalling services...');
+
+    PhpCgi::uninstall();
+
+    PhpCgi::install();
+});
+
+/**
+ */
+$app->command('php:uninstall', function () {
+    info('Uninstalling PHP services...');
+
+    PhpCgi::uninstall();
+
+    info('PHP services uninstalled. Run php:install to install again');
+});
+
+/**
+ */
+$app->command('xdebug:install', function () {
+    info('Reinstalling xDebug services...');
+
+    PhpCgiXdebug::uninstall();
+
+    PhpCgiXdebug::install();
+});
+
+/**
+ */
+$app->command('xdebug:uninstall', function () {
+    info('Uninstalling xDebug services...');
+
+    PhpCgiXdebug::uninstall();
+
+    info('xDebug services uninstalled. Run xdebug:install to install again');
+});
+
+/**
  * Install Valet and any required services.
  */
 $app->command('install', function () {
@@ -94,6 +166,8 @@ if (is_dir(VALET_HOME_PATH)) {
     $app->command('park [path]', function ($path = null) {
         Configuration::addPath($path ?: getcwd());
 
+//        Site::publishParkedNginxConf($path ?: getcwd());
+
         info(($path === null ? 'This' : "The [{$path}]")." directory has been added to Valet's paths.");
     })->descriptions('Register the current working (or specified) directory with Valet');
 
@@ -105,6 +179,16 @@ if (is_dir(VALET_HOME_PATH)) {
 
         table(['Site', 'SSL', 'URL', 'Path'], $parked->all());
     })->descriptions('Display all the current sites within parked paths');
+
+//    /**
+//     * Get all the current sites within paths parked with 'park {path}'.
+//     */
+//    $app->command('nginx:publish', function ($type) {
+//        if($type === 'nginx') {
+//            Site::publishNginxConf();
+//        }
+//
+//    })->descriptions('Publish ');
 
     /**
      * Remove the current working directory from the paths configuration.


### PR DESCRIPTION
Hey! Amazing working on the package <3

Currently it's missing the multiple PHP versions management and the `valet use` command is disabled.

This PR adds below new commands and enables `valet use` to switch between PHP versions. 

```
php:add            Add PHP by specifying a path
php:install        Reinstall all PHP services from [valet php:list]
php:list           List all PHP services
php:remove         Remove PHP by specifying a path
php:uninstall      Uninstall all PHP services from [valet php:list]

use                Change the version of PHP used by valet
```

Examples:
`valet php:add "c:\php-7.3.29"`
`valet php:remove "c:\php-8.1.2"`
`valet use 8.0.15`


`$ valet php:list`
```
Listing PHP services...
+---------+---------------+------+-------------+---------+
| Version | Path          | Port | xDebug Port | Default |
+---------+---------------+------+-------------+---------+
| 8.0.15  | C:\php-8.0.15 | 9001 | 9101        |         |
| 8.1.2   | C:\php-8.1.2  | 9002 | 9102        |         |
| 7.4.27  | C:\php-7.4.27 | 9004 | 9104        |         |
| 7.3.29  | C:\php-7.3.29 | 9005 | 9105        | X       |
+---------+---------------+------+-------------+---------+
```

I'm further working on a feature to enable individual site to use a specific PHP version :)
