### PR TITLE
Fix some old versions PHP find XDebug to throw "Could not find a release for PHP VERSION"  exception

### DIFF
--- a/bin/php.ps1
+++ b/bin/php.ps1
@@ -34,7 +34,7 @@ function Find-XdebugRelease {
     $architecture = if ([Environment]::Is64BitProcess) {"-x86_64"} else {""}
     # php_xdebug-3.0.3-7.4-vc15-nts-x86_64.dll
     # php_xdebug-3.0.3-8.0-vs16-nts-x86_64.dll
-    $html = (Invoke-WebRequest "${xdebugReleasesUrl}/download" -UseBasicParsing).rawcontent
+    $html = (Invoke-WebRequest "${xdebugReleasesUrl}/download/historical" -UseBasicParsing).rawcontent
 
     if ($html -match "php_xdebug-(.+)-${phpVersion}-vc15-nts${architecture}.dll") {
         return "${xdebugReleasesUrl}/files/" + $matches[0]


### PR DESCRIPTION
Fix some old versions PHP find XDebug to throw "Could not find a release for PHP VERSION"  exception