### PR TITLE
Fix for serving sites when proxies are added

### DIFF
--- a/cli/stubs/secure.valet.conf
+++ b/cli/stubs/secure.valet.conf
@@ -1,11 +1,11 @@
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     return 302 https://$host$request_uri;
 }
 
 server {
-    listen 443 ssl http2;
+    listen 127.0.0.1:443 ssl http2;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;
@@ -49,7 +49,7 @@ server {
 }
 
 server {
-    listen 60;
+    listen 127.0.0.1:60;
     server_name VALET_SITE www.VALET_SITE *.VALET_SITE;
     root /;
     charset utf-8;

--- a/cli/stubs/valet.conf
+++ b/cli/stubs/valet.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80 default_server;
+    listen 127.0.0.1:80 default_server;
     root /;
     charset utf-8;
     client_max_body_size 128M;


### PR DESCRIPTION
When the proxy is added, they serve default SSL and listen over `127.0.0.1:80` and `127.0.0.1:443` 

However, the normal secure laravel configs didn't listen over `127.0.0.1:443`, which caused landing over proxied website


This fix is tested locally and works with SSL for both normal links & secured proxies