### PR TITLE
Update Ngrok version and Add support for --domain parameter

### DIFF
--- a/cli/valet.php
+++ b/cli/valet.php
@@ -241,15 +241,16 @@ if (is_dir(VALET_HOME_PATH)) {
      * Generate a publicly accessible URL for your project.
      */
     // TODO: custom domain and ngrok params
-    $app->command('share [domain] [--authtoken=] [--host-header=] [--hostname=] [--region=] [--subdomain=]',
-        function ($domain = null, $authtoken = null, $hostheader = null, $hostname = null, $region = null, $subdomain = null) {
-            $url = ($domain ?: strtolower(Site::host(getcwd()))).'.'.Configuration::read()['tld'];
+    $app->command('share [local_domain] [--authtoken=] [--host-header=] [--hostname=] [--region=] [--domain=] [--subdomain=]',
+        function ($local_domain = null, $authtoken = null, $hostheader = null, $hostname = null, $region = null, $domain = null, $subdomain = null) {
+            $url = ($local_domain ?: strtolower(Site::host(getcwd()))).'.'.Configuration::read()['tld'];
 
             Ngrok::start($url, Site::port($url), array_filter([
                 'authtoken' => $authtoken,
                 'host-header' => $hostheader,
                 'hostname' => $hostname,
                 'region' => $region,
+                'domain' => $domain,
                 'subdomain' => $subdomain,
             ]));
         })->defaults([


### PR DESCRIPTION
- Update ngrok to version from 2.3.25 to 3.3.1
- Upgrade ngrok to it's latest version 3.3.1
- Add support for --domain parameter from cli interface

**Deprecated**  `--subdomain` and `--hostname` flags in favor of `--domain` flag which accepts a fully qualified domain.

[Read more: Agent CLI and API changes](https://ngrok.com/blog-post/new-ngrok-domains)